### PR TITLE
fix: return instance of array from cy.map

### DIFF
--- a/commands/map.js
+++ b/commands/map.js
@@ -2,13 +2,22 @@
 
 Cypress.Commands.addQuery('map', (fnOrProperty) => {
   const message =
-    typeof fnOrProperty === 'string' ? fnOrProperty : fnOrProperty.name
+    typeof fnOrProperty === 'string'
+      ? fnOrProperty
+      : fnOrProperty.name
   const log = Cypress.log({ name: 'map', message })
 
-  return ($el) =>
-    Cypress._.map($el, (item) =>
-      typeof fnOrProperty === 'string'
-        ? item[fnOrProperty]
-        : fnOrProperty(item),
-    )
+  return ($el) => {
+    // use a spread so that the result is an array
+    // and used the Array constructor in the current iframe
+    // so it passes the "instanceOf Array" assertion
+    const list = [
+      ...Cypress._.map($el, (item) =>
+        typeof fnOrProperty === 'string'
+          ? item[fnOrProperty]
+          : fnOrProperty(item),
+      ),
+    ]
+    return list
+  }
 })

--- a/cypress/e2e/instance.cy.js
+++ b/cypress/e2e/instance.cy.js
@@ -1,0 +1,21 @@
+/// <reference types="cypress" />
+// @ts-check
+
+import '../../commands'
+
+it('checks instance of array', () => {
+  expect([1, 2, 3]).to.be.an.instanceOf(Array)
+})
+
+it('works before cy.map', () => {
+  cy.wrap(['one', 'a', 'four']).should('be.an.instanceOf', Array)
+})
+
+it('maps to an array', () => {
+  cy.wrap(['one', 'a', 'four'])
+    .should('be.an.instanceOf', Array)
+    .map('length')
+    .should('deep.equal', [3, 1, 4])
+    .and('be.an', 'array')
+    .and('be.an.instanceOf', Array)
+})


### PR DESCRIPTION
This test now passes after `cy.map` query
```js
it('maps to an array', () => {
  cy.wrap(['one', 'a', 'four'])
    .should('be.an.instanceOf', Array)
    .map('length')
    .should('deep.equal', [3, 1, 4])
    .and('be.an', 'array')
    .and('be.an.instanceOf', Array)
})
```