### PR TITLE
fix: add timeout to mapInvoke query

### DIFF
--- a/commands/map-invoke.js
+++ b/commands/map-invoke.js
@@ -2,7 +2,19 @@
 
 const { registerQuery } = require('./utils')
 
-registerQuery('mapInvoke', (methodName, ...args) => {
+registerQuery('mapInvoke', function (methodName, ...args) {
+  if (args.length > 0) {
+    const lastArgument = args.at(-1)
+    if (
+      lastArgument &&
+      Cypress._.isFinite(lastArgument.timeout) &&
+      lastArgument.timeout > 0
+    ) {
+      // make sure this query command respects the timeout option
+      this.set('timeout', lastArgument.timeout)
+    }
+  }
+
   let message = methodName
   if (args.length) {
     message += ' ' + args.map((x) => JSON.stringify(x)).join(', ')

--- a/cypress/e2e/map-invoke.cy.js
+++ b/cypress/e2e/map-invoke.cy.js
@@ -12,3 +12,31 @@ it('confirms the prices', () => {
     .map(parseFloat)
     .should('deep.equal', [1.99, 2.99, 3.99])
 })
+
+it('respects the timeout option', () => {
+  const strings = []
+  setTimeout(() => {
+    strings.push('a')
+  }, 1000)
+  setTimeout(() => {
+    strings.push('b')
+  }, 2000)
+  setTimeout(() => {
+    strings.push('c')
+  }, 3000)
+  setTimeout(() => {
+    strings.push('d')
+  }, 4000)
+  setTimeout(() => {
+    strings.push('e')
+  }, 5000)
+  setTimeout(() => {
+    strings.push('f')
+  }, 6000)
+  setTimeout(() => {
+    strings.push('g')
+  }, 7000)
+  cy.wrap(strings)
+    .mapInvoke('toUpperCase', { timeout: 10_000 })
+    .should('deep.equal', ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "cy-spok": "^1.5.2",
-        "cypress": "^13.5.1",
+        "cypress": "^13.6.0",
         "prettier": "^3.0.0",
         "semantic-release": "^22.0.0",
         "stop-only": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "cy-spok": "^1.5.2",
-    "cypress": "^13.5.1",
+    "cypress": "^13.6.0",
     "prettier": "^3.0.0",
     "semantic-release": "^22.0.0",
     "stop-only": "^3.1.2",


### PR DESCRIPTION
Checks the last argument to `.mapInvoke()` to see if it has `timeout` number