### PR TITLE
fix: make cy.map use its parent command timeout

### DIFF
--- a/commands/map.js
+++ b/commands/map.js
@@ -1,13 +1,15 @@
 /// <reference types="cypress" />
 
-const { registerQuery } = require('./utils')
+const { registerQuery, findTimeout } = require('./utils')
 
 const repoUrl = 'https://github.com/bahmutov/cypress-map'
 const repoLink = `[${repoUrl}](${repoUrl})`
 
 registerQuery('map', function (fnOrProperty, options = {}) {
+  const timeout = findTimeout(this, options)
+
   // make sure this query command respects the timeout option
-  this.set('timeout', options.timeout)
+  this.set('timeout', timeout)
 
   if (Cypress._.isPlainObject(fnOrProperty)) {
     Object.keys(fnOrProperty).forEach((key) => {
@@ -22,7 +24,7 @@ registerQuery('map', function (fnOrProperty, options = {}) {
 
     const log =
       options.log !== false &&
-      Cypress.log({ name: 'map', message, timeout: options.timeout })
+      Cypress.log({ name: 'map', message, timeout })
   } else {
     const message =
       typeof fnOrProperty === 'string'
@@ -31,7 +33,7 @@ registerQuery('map', function (fnOrProperty, options = {}) {
 
     const log =
       options.log !== false &&
-      Cypress.log({ name: 'map', message, timeout: options.timeout })
+      Cypress.log({ name: 'map', message, timeout })
   }
 
   return ($el) => {

--- a/commands/utils.js
+++ b/commands/utils.js
@@ -21,4 +21,31 @@ function registerCommand(name, options, fn) {
   }
 }
 
-module.exports = { registerQuery, registerCommand }
+/**
+ * Finds the timeout option from this command or from its parent command
+ */
+function findTimeout(cmd, options = {}) {
+  if (Cypress._.isFinite(options.timeout)) {
+    return options.timeout
+  }
+
+  const defaultTimeout = Cypress.config('defaultCommandTimeout')
+  if (!cmd) {
+    return defaultTimeout
+  }
+  const prev = cmd.attributes?.prev
+  const prevTimeout = prev?.attributes?.timeout
+  if (Cypress._.isFinite(prevTimeout)) {
+    return prevTimeout
+  }
+  if (prev.attributes.args?.length) {
+    const lastArg = prev.attributes.args.at(-1)
+    if (Cypress._.isFinite(lastArg?.timeout)) {
+      return lastArg?.timeout
+    }
+  }
+
+  return defaultTimeout
+}
+
+module.exports = { registerQuery, registerCommand, findTimeout }

--- a/cypress/e2e/map.cy.js
+++ b/cypress/e2e/map.cy.js
@@ -114,6 +114,29 @@ it('respects the timeout option', () => {
     .should('deep.equal', ['Joe', 'Anna'])
 })
 
+it('respects the timeout option from the parent command', () => {
+  const people = [
+    {
+      name: {
+        first: 'Joe',
+        last: 'Smith',
+      },
+    },
+  ]
+  setTimeout(() => {
+    people.push({
+      name: {
+        first: 'Anna',
+        last: 'Kova',
+      },
+    })
+  }, 6000)
+  cy.wrap(people, { timeout: 10_000 })
+    .map('name') // should use the timeout from the parent command
+    .map('first') // should use the timeout from the parent command
+    .should('deep.equal', ['Joe', 'Anna'])
+})
+
 // enable only to see the thrown errors
 // https://github.com/bahmutov/cypress-map/issues/74
 describe.skip(


### PR DESCRIPTION
Use the parent timeout in a situation like this

```js
cy.wrap(people, { timeout: 10_000 })
  .map('name') // should use the timeout from the parent command
  .map('first') // should use the timeout from the parent command
  .should('deep.equal', ['Joe', 'Anna'])
```