### PR TITLE
fix: add log to cy.difference

### DIFF
--- a/src/commands/difference.js
+++ b/src/commands/difference.js
@@ -3,6 +3,8 @@
 const { registerQuery } = require('./utils')
 
 registerQuery('difference', (expected) => {
+  const log = Cypress.log({ name: 'difference', type: 'child' })
+
   const names = Object.keys(expected)
   return (subject) => {
     const diff = {}
@@ -30,6 +32,10 @@ registerQuery('difference', (expected) => {
       if (!(name in expected)) {
         diff[name] = { extra: true, actual: subject[name] }
       }
+    })
+
+    log.set('consoleProps', () => {
+      return { expected, subject, diff }
     })
 
     return diff


### PR DESCRIPTION
Print the message in the Command Log and add console log props

<img width="735" alt="Screenshot 2024-03-06 at 19 26 53" src="https://github.com/bahmutov/cypress-map/assets/2212006/fa678aca-8b8e-4ac4-b522-a5c98ca16821">
